### PR TITLE
Add templates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ keywords = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "pyyaml"
+    "pyyaml",
+    "Jinja2"
 ]
 dynamic = ["version"]
 

--- a/src/ga4gh/gks/metaschema/scripts/y2t.py
+++ b/src/ga4gh/gks/metaschema/scripts/y2t.py
@@ -4,8 +4,15 @@
 import os
 import pathlib
 import sys
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
 
 from ga4gh.gks.metaschema.tools.source_proc import YamlSchemaProcessor
+
+templates_dir = Path(__file__).resolve().parents[4] / "templates"
+env = Environment(loader=FileSystemLoader(templates_dir))
+
 
 
 def resolve_type(class_property_definition: dict) -> str:
@@ -87,22 +94,22 @@ def main(proc_schema: YamlSchemaProcessor) -> None:
         with open(proc_schema.def_fp / (class_name + ".rst"), "w") as f:
             maturity = class_definition.get("maturity", "")
             if maturity == "draft":
+                template = env.get_template("maturity")
                 print(
-                    """
-.. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
-    the :ref:`maturity-model`.
-                      
-                    """,
+                    template.render(
+                        info="warning",
+                        maturity_level="draft",
+                        modifier="significantly"
+                    ),
                     file=f,
                 )
             elif maturity == "trial use":
                 print(
-                    """
-.. note:: This data class is at a **trial use** maturity level and may change
-    in future releases. Maturity levels are described in the :ref:`maturity-model`.
-                      
-                    """,
+                    template.render(
+                        info="note",
+                        maturity_level="trial use",
+                        modifier=""
+                    ),
                     file=f,
                 )
             print("**Computational Definition**\n", file=f)

--- a/src/templates/maturity
+++ b/src/templates/maturity
@@ -1,0 +1,4 @@
+.. {{ info }}:: This data class is at a **{{ maturity_level }}** maturity level and may change
+    {{ modifier }} in future releases. Maturity levels are described in
+    the :ref:`maturity-model`.
+

--- a/tests/data/vrs/def/Adjacency.rst
+++ b/tests/data/vrs/def/Adjacency.rst
@@ -1,9 +1,7 @@
-
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
-                    
+
 **Computational Definition**
 
 The `Adjacency` class can represent either the termination of a sequence or the adjoining of the end of a sequence with the beginning of an adjacent sequence, potentially with an intervening linker sequence.

--- a/tests/data/vrs/def/Allele.rst
+++ b/tests/data/vrs/def/Allele.rst
@@ -1,9 +1,7 @@
-
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
-                    
+
 **Computational Definition**
 
 The state of a molecule at a :ref:`Location`.

--- a/tests/data/vrs/def/CopyNumberChange.rst
+++ b/tests/data/vrs/def/CopyNumberChange.rst
@@ -1,9 +1,7 @@
-
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
-                    
+
 **Computational Definition**
 
 An assessment of the copy number of a :ref:`Location` or a :ref:`Gene` within a system (e.g. genome, cell, etc.) relative to a baseline ploidy.

--- a/tests/data/vrs/def/CopyNumberCount.rst
+++ b/tests/data/vrs/def/CopyNumberCount.rst
@@ -1,9 +1,7 @@
-
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
-                    
+
 **Computational Definition**
 
 The absolute count of discrete copies of a :ref:`Location` or :ref:`Gene`, within a system (e.g. genome, cell, etc.).

--- a/tests/data/vrs/def/Expression.rst
+++ b/tests/data/vrs/def/Expression.rst
@@ -1,9 +1,7 @@
-
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
-                    
+
 **Computational Definition**
 
 Representation of a variation by a specified nomenclature or syntax for a Variation object.  Common examples of expressions for the description of molecular variation include the HGVS  and ISCN nomenclatures.

--- a/tests/data/vrs/def/Haplotype.rst
+++ b/tests/data/vrs/def/Haplotype.rst
@@ -1,9 +1,7 @@
-
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
-                    
+
 **Computational Definition**
 
 An ordered set of co-occurring :ref:`variants <Variation>` on the same molecule.

--- a/tests/data/vrs/def/LengthExpression.rst
+++ b/tests/data/vrs/def/LengthExpression.rst
@@ -1,9 +1,7 @@
-
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
-                    
+
 **Computational Definition**
 
 A sequence expressed only by its length.

--- a/tests/data/vrs/def/LiteralSequenceExpression.rst
+++ b/tests/data/vrs/def/LiteralSequenceExpression.rst
@@ -1,9 +1,7 @@
-
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
-                    
+
 **Computational Definition**
 
 An explicit expression of a Sequence.

--- a/tests/data/vrs/def/Range.rst
+++ b/tests/data/vrs/def/Range.rst
@@ -1,9 +1,7 @@
-
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
-                    
+
 **Computational Definition**
 
 An inclusive range of values bounded by one or more integers.

--- a/tests/data/vrs/def/ReferenceLengthExpression.rst
+++ b/tests/data/vrs/def/ReferenceLengthExpression.rst
@@ -1,9 +1,7 @@
-
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
-                    
+
 **Computational Definition**
 
 An expression of a length of a sequence from a repeating reference.

--- a/tests/data/vrs/def/Residue.rst
+++ b/tests/data/vrs/def/Residue.rst
@@ -1,9 +1,7 @@
-
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
-                    
+
 **Computational Definition**
 
 A character representing a specific residue (i.e., molecular species) or groupings of these ("ambiguity codes"), using `one-letter IUPAC abbreviations <https://en.wikipedia.org/wiki/International_Union_of_Pure_and_Applied_Chemistry#Amino_acid_and_nucleotide_base_codes>`_ for nucleic acids and amino acids.

--- a/tests/data/vrs/def/SequenceLocation.rst
+++ b/tests/data/vrs/def/SequenceLocation.rst
@@ -1,9 +1,7 @@
-
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
-                    
+
 **Computational Definition**
 
 A :ref:`Location` defined by an interval on a referenced :ref:`Sequence`.

--- a/tests/data/vrs/def/SequenceReference.rst
+++ b/tests/data/vrs/def/SequenceReference.rst
@@ -1,9 +1,7 @@
-
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
-                    
+
 **Computational Definition**
 
 A sequence of nucleic or amino acid character codes.

--- a/tests/data/vrs/def/SequenceString.rst
+++ b/tests/data/vrs/def/SequenceString.rst
@@ -1,9 +1,7 @@
-
 .. warning:: This data class is at a **draft** maturity level and may change
-    significantly in future releases. Maturity levels are described in 
+    significantly in future releases. Maturity levels are described in
     the :ref:`maturity-model`.
-                      
-                    
+
 **Computational Definition**
 
 A character string of :ref:`Residues <Residue>` that represents a biological sequence using the conventional sequence order (5’-to-3’ for nucleic acid sequences, and amino-to-carboxyl for amino acid sequences). IUPAC ambiguity codes are permitted in Sequence Strings.


### PR DESCRIPTION
This commit adds a template for the maturity string used in `y2t.py`. The templating engine changed the whitespace in some of the reStructuredText files.